### PR TITLE
Don't manage namespace if namespace is set to kube-system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Apply component template ([#2])
 - Rewrite component to use dependencies ([#3])
+- Ensure component does not take ownership of namespace `kube-system` ([#4])
 
 [Unreleased]: https://github.com/projectsyn/component-csi-cloudscale/compare/d3d1c750bf423dc86d9a553a4f2a060912f8cb90...HEAD
 
 [#2]: https://github.com/projectsyn/component-csi-cloudscale/pull/2
 [#3]: https://github.com/projectsyn/component-csi-cloudscale/pull/3
+[#4]: https://github.com/projectsyn/component-csi-cloudscale/pull/4

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -66,7 +66,7 @@ local customRBAC = if isOpenshift then [
 ] else [];
 
 {
-  '00_namespace': kube.Namespace(params.namespace) + if isOpenshift then {
+  [if params.namespace != 'kube-system' then '00_namespace']: kube.Namespace(params.namespace) + if isOpenshift then {
     metadata+: {
       annotations+: {
         'openshift.io/node-selector': '',

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -2,6 +2,22 @@
 
 The parent key for all of the following parameters is `csi_cloudscale`.
 
+== `namespace`
+
+[horizontal]
+type:: string
+default:: `syn-csi-cloudscale`
+
+The namespace in which to install the driver.
+Unless `kube-system` is chosen, the component will take ownership of the
+namespace.
+In K8s prior to 1.17, the driver will not run in namespaces other than
+`kube-system`, as the priority class `system-cluster-critical` is only
+available to pods in namespace `kube-system`.
+See
+https://kubernetes.io/docs/concepts/policy/resource-quotas/#limit-priority-class-consumption-by-default[the
+Kubernetes priority class consumption] documentation for instructions on how
+to allow the driver to run in a namespace other than `kube-system`.
 
 == `version`
 


### PR DESCRIPTION
This is a safe-guard against the component grabbing ownership of namespace `kube-system`, if this namespace is configured somewhere in the hierarchy.

Users may want to install the csi-cloudscale plugin in `kube-system`, as pods with priority class `system-cluster-critical` can only be created in `kube-system` in K8s prior to 1.17. For 1.17+ the `system-cluster-critical` priority class needs to be explicitly enabled for namespaces other than kube-system using an admission controller config file, cf. [1].

[1] https://kubernetes.io/docs/concepts/policy/resource-quotas/#limit-priority-class-consumption-by-default

## Checklist
- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.
