### PR TITLE
Bump CSI Cloudscale version to v1.3.0

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,7 +1,7 @@
 parameters:
   csi_cloudscale:
     namespace: syn-csi-cloudscale
-    version: v1.1.2
+    version: v1.3.0
     # This switch is required to selectively disable the commoponent
     # TODO: Reevaluate the need for this once disabeling got implemented.
     # See: https://github.com/projectsyn/commodore/issues/71

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -23,7 +23,7 @@ to allow the driver to run in a namespace other than `kube-system`.
 
 [horizontal]
 type:: string
-default:: `v1.1.2`
+default:: `v1.3.0`
 
 Version of the driver to install.
 See https://github.com/cloudscale-ch/csi-cloudscale/releases[available versions].


### PR DESCRIPTION
This version supports VMs which use the new virtio-scsi option to attach disks.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
