### PR TITLE
Update the version to 2.1.0 and rename the provisioner name

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,7 +1,7 @@
 parameters:
   csi_cloudscale:
     namespace: syn-csi-cloudscale
-    version: v1.3.1
+    version: v2.1.0
     # This switch is required to selectively disable the commoponent
     # TODO: Reevaluate the need for this once disabeling got implemented.
     # See: https://github.com/projectsyn/commodore/issues/71

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -8,7 +8,7 @@ local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift
 
 local config = {
   allowVolumeExpansion: true,
-  provisioner: 'ch.cloudscale.csi',
+  provisioner: 'csi.cloudscale.ch',
 };
 
 local storageclasses = [ [

--- a/docs/modules/ROOT/pages/how-tos/upgrade-1.x-to-2.x.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-1.x-to-2.x.adoc
@@ -2,6 +2,11 @@
 
 This guide describes the steps to perform an upgrade of the component from version 1.x to 2.x.
 
+[WARNING]
+====
+Before upgrading to version 2.x, please ensure that your Kubernetes cluster is running the version https://github.com/cloudscale-ch/csi-cloudscale#kubernetes-compatibility[1.17 or later].
+====
+
 ====
 Requirements
 

--- a/docs/modules/ROOT/pages/how-tos/upgrade-1.x-to-2.x.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-1.x-to-2.x.adoc
@@ -1,0 +1,55 @@
+= Upgrade from 1.x to 2.x
+
+This guide describes the steps to perform an upgrade of the component from version 1.x to 2.x.
+
+====
+Requirements
+
+* `commodore`
+* `kubectl`
+* `shell`
+====
+
+== Step-by-step guide
+
+The essential part of the upgrade is the renaming of the provisioner name from `ch.cloudscale.csi` to `csi.cloudscale.ch`.
+This implies that all `PersistentVolumes` require an changed annotation and all `StorageClasses` need to be recreated with the new provisioner name.
+
+The upgrade itself does not affect the data path, so no interrupt of IO should be there for applications.
+However, during the upgrade volume changes might not work, so doing that off hours is suggested.
+All steps should be done together.
+
+. Change the provisioner annotation for all volumes from `ch.cloudscale.csi` to `csi.cloudscale.ch`:
++
+[source,bash]
+----
+wget https://raw.githubusercontent.com/cloudscale-ch/csi-cloudscale/master/scripts/fix-annotation.sh
+chmod +x fix-annotation.sh
+./fix-annotation.sh migrate
+rm fix-annotation.sh
+----
++
+. Update the component:
++
+[source,yaml]
+----
+parameters:
+  components:
+    csi-cloudscale:
+      version: v2.0.0
+----
++
+. Compile and push the catalog
++
+. Delete existing csi-cloudscale storage classes
++
+[source,bash]
+----
+oc delete sc bulk bulk-encrypted ssd ssd-encrypted
+----
++
+[NOTE]
+====
+The storageclasses are part of the component and will be recreated using the new parameters.
+Kubernetes does not allow to change the provisioner after creating the object, so the storageclass objects have to be recreated.
+====

--- a/docs/modules/ROOT/pages/how-tos/upgrade-1.x-to-2.x.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-1.x-to-2.x.adoc
@@ -13,11 +13,11 @@ Requirements
 == Step-by-step guide
 
 The essential part of the upgrade is the renaming of the provisioner name from `ch.cloudscale.csi` to `csi.cloudscale.ch`.
-This implies that all `PersistentVolumes` require an changed annotation and all `StorageClasses` need to be recreated with the new provisioner name.
+This implies that all `PersistentVolumes` require a changed annotation and all `StorageClasses` need to be recreated with the new provisioner name.
 
-The upgrade itself does not affect the data path, so no interrupt of IO should be there for applications.
-However, during the upgrade volume changes might not work, so doing that off hours is suggested.
-All steps should be done together.
+The upgrade itself does not affect the data path, so applications should not experience IO interrupts during the upgrade.
+However, during the upgrade, volume provisioning and volume changes might not work for short periods of time, so it's strongly recommended to perform the upgrade during off hours.
+To minimize the visible impact of the upgrade, all steps should be done together.
 
 . Change the provisioner annotation for all volumes from `ch.cloudscale.csi` to `csi.cloudscale.ch`:
 +

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -23,7 +23,7 @@ to allow the driver to run in a namespace other than `kube-system`.
 
 [horizontal]
 type:: string
-default:: `v1.3.1`
+default:: `v2.1.0`
 
 Version of the driver to install.
 See https://github.com/cloudscale-ch/csi-cloudscale/releases[available versions].

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -1,2 +1,7 @@
 * xref:index.adoc[Home]
+
+.How-to guides
+* xref:how-tos/upgrade-1.x-to-2.x.adoc[Upgrade 1.x to 2.x]
+
+.Technical reference
 * xref:references/parameters.adoc[Parameters]


### PR DESCRIPTION
The provisioner name has been renamed from v1.3.1 to v2.0.0 from
ch.cloudscale.csi to csi.cloudscale.ch. The storageclasses needs
to be updated.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [ ] Update the ./CHANGELOG.md.
