### PR TITLE
Configure a default filesystem type

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -7,3 +7,4 @@ parameters:
     # See: https://github.com/projectsyn/commodore/issues/71
     enabled: true
     api_token: ?{vaultkv:${cluster:tenant}/${cluster:name}/cloudscale/token}
+    fs_type: ext4

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -14,11 +14,13 @@ local config = {
 local storageclasses = [ [
   sc.storageClass(type) {
     parameters: {
+      fsType: params.fs_type,
       'csi.cloudscale.ch/volume-type': type,
     },
   } + config,
   sc.storageClass(type + '-encrypted') {
     parameters+: {
+      fsType: params.fs_type,
       'csi.cloudscale.ch/volume-type': type,
       'csi.cloudscale.ch/luks-encrypted': 'true',
       'csi.cloudscale.ch/luks-cipher': 'aes-xts-plain64',

--- a/docs/modules/ROOT/pages/how-tos/upgrade-1.x-to-2.x.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-1.x-to-2.x.adoc
@@ -41,7 +41,7 @@ rm fix-annotation.sh
 parameters:
   components:
     csi-cloudscale:
-      version: v2.0.0
+      version: v2.1.0
 ----
 +
 . Compile and push the catalog

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -41,3 +41,12 @@ default:: Vault reference
 
 Cloudscale API token to be used by the CSI driver.
 This should be a reference to a secret in Vault instead of the plaintext token.
+
+
+=== `fs_type`
+
+[horizontal]
+type:: string
+default:: ext4
+
+The filesystem type used in the storage classes.


### PR DESCRIPTION
With version 2.0 the external provisioner has removed the default
fsType [1]. With no filesystem set, Kubernetes does not set the
group ID and this causes volumes are mounted with root permissions
only. Some distributions like OpenShift disallow access in this case.
    
[1] https://github.com/kubernetes-csi/external-provisioner/blob/master/CHANGELOG/CHANGELOG-2.0.md#changelog-since-v160
[2] https://github.com/NetApp/trident/issues/556#issuecomment-808144203

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
