### PR TITLE
Remove parameter `enabled`

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -2,10 +2,6 @@ parameters:
   csi_cloudscale:
     namespace: syn-csi-cloudscale
     version: v3.5.0
-    # This switch is required to selectively disable the commoponent
-    # TODO: Reevaluate the need for this once disabeling got implemented.
-    # See: https://github.com/projectsyn/commodore/issues/71
-    enabled: true
     api_token: ?{vaultkv:${cluster:tenant}/${cluster:name}/cloudscale/token}
     fs_type: ext4
     driver_daemonset_tolerations: {}

--- a/component/app.jsonnet
+++ b/component/app.jsonnet
@@ -5,6 +5,6 @@ local argocd = import 'lib/argocd.libjsonnet';
 
 local app = argocd.App('csi-cloudscale', params.namespace, secrets=true);
 
-if params.enabled then {
+{
   'csi-cloudscale': app,
-} else {}
+}

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -25,15 +25,6 @@ See https://github.com/cloudscale-ch/csi-cloudscale/releases[available versions]
 See https://github.com/cloudscale-ch/csi-cloudscale#kubernetes-compatibility[Kubernetes compatibility] to choose the right version for your cluster.
 
 
-== `enabled`
-
-[horizontal]
-type:: boolean
-default:: `true`
-
-Switch to enable or disable the component. See https://github.com/projectsyn/commodore/issues/71[this issue] for further details.
-
-
 == `api_token`
 
 [horizontal]


### PR DESCRIPTION
We don't have any OpenShift 3 clusters left, and don't need this parameter anymore. Since #47 will be a breaking change anyway, it makes sense to also remove the parameter.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
