### PR TITLE
Bump csi-cloudscale to v3.1.0

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,7 +1,7 @@
 parameters:
   csi_cloudscale:
     namespace: syn-csi-cloudscale
-    version: v3.0.0
+    version: v3.1.0
     # This switch is required to selectively disable the commoponent
     # TODO: Reevaluate the need for this once disabeling got implemented.
     # See: https://github.com/projectsyn/commodore/issues/71

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -5,6 +5,12 @@
 See the xref:references/parameters.adoc[parameters] reference for further details.
 
 
+== Compatibility
+
+Not every version of the cloudscale.ch CSI driver is compatible with every Kubernetes versions.
+See https://github.com/cloudscale-ch/csi-cloudscale#kubernetes-compatibility["Kubernetes Compatibility" in csi-cloudscale's README] for more information.
+
+
 == StorageClasses
 
 The following storage classess are set up by this component:

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -18,7 +18,7 @@ See https://kubernetes.io/docs/concepts/policy/resource-quotas/#limit-priority-c
 
 [horizontal]
 type:: string
-default:: `v2.1.0`
+default:: `v3.1.0`
 
 Version of the driver to install.
 See https://github.com/cloudscale-ch/csi-cloudscale/releases[available versions].

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -22,6 +22,7 @@ default:: `v3.1.0`
 
 Version of the driver to install.
 See https://github.com/cloudscale-ch/csi-cloudscale/releases[available versions].
+See https://github.com/cloudscale-ch/csi-cloudscale#kubernetes-compatibility[Kubernetes compatibility] to choose the right version for your cluster.
 
 
 === `enabled`


### PR DESCRIPTION
https://github.com/cloudscale-ch/csi-cloudscale/blob/master/CHANGELOG.md#v310---20211105

Main features:

- Use quay.io instead of Docker Hub.
- Support raw block volume mode (not in conjunction with LUKS for now)

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
