### PR TITLE
Add support for configuring tolerations on the node driver DaemonSet 

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -8,3 +8,4 @@ parameters:
     enabled: true
     api_token: ?{vaultkv:${cluster:tenant}/${cluster:name}/cloudscale/token}
     fs_type: ext4
+    driver_daemonset_tolerations: {}

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -25,7 +25,7 @@ See https://github.com/cloudscale-ch/csi-cloudscale/releases[available versions]
 See https://github.com/cloudscale-ch/csi-cloudscale#kubernetes-compatibility[Kubernetes compatibility] to choose the right version for your cluster.
 
 
-=== `enabled`
+== `enabled`
 
 [horizontal]
 type:: boolean
@@ -34,7 +34,7 @@ default:: `true`
 Switch to enable or disable the component. See https://github.com/projectsyn/commodore/issues/71[this issue] for further details.
 
 
-=== `api_token`
+== `api_token`
 
 [horizontal]
 type:: string

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -44,10 +44,47 @@ Cloudscale API token to be used by the CSI driver.
 This should be a reference to a secret in Vault instead of the plaintext token.
 
 
-=== `fs_type`
+== `fs_type`
 
 [horizontal]
 type:: string
 default:: ext4
 
 The filesystem type used in the storage classes.
+
+== `driver_daemonset_tolerations`
+
+[horizontal]
+type:: dictionary
+default:: `{}`
+
+Tolerations that should be applied to the CSI node driver daemonset.
+The component will transform entries in the dictionary to valid Kubernetes `tolerations` entries.
+The component will reuse the key in the dictionary as value for field `key` in the `tolerations` entry.
+
+=== Example
+
+Allow the CSI node driver daemonset to be scheduled on nodes which have a `storagenode` taint.
+
+.cluster-id.yaml
+[source,yaml]
+----
+parameters:
+  csi_cloudscale:
+    driver_daemonset_tolerations:
+      storagenode:
+        operator: Exists
+----
+
+.Resulting configuration in the node driver DaemonSet
+[source,yaml]
+----
+# ... remaining object omitted ...
+spec:
+  template:
+    spec:
+      # ... remaining spec omitted ...
+      tolerations:
+        - key: storagenode
+          operator: Exists
+----


### PR DESCRIPTION
Add a new parameter which allows users to configure tolerations for the node driver DaemonSet. This can be useful if deployments on tainted nodes should be able to use cloudscale.ch CSI volumes.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [X] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
