### PR TITLE
Configure resource requests and limits

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -9,3 +9,6 @@ parameters:
     api_token: ?{vaultkv:${cluster:tenant}/${cluster:name}/cloudscale/token}
     fs_type: ext4
     driver_daemonset_tolerations: {}
+    resources:
+      controller: {}
+      csi_driver: {}

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -88,3 +88,60 @@ spec:
         - key: storagenode
           operator: Exists
 ----
+
+== `resources`
+
+[horizontal]
+type:: dict
+default::
++
+[source,yaml]
+----
+controller: {}
+csi_driver: {}
+----
+
+Resource requests and limits to apply to individual CSI driver containers.
+
+By default, each container is configured with the following requests and limits:
+
+[source,yaml]
+----
+resources:
+  requests:
+    cpu: 20m
+    memory: 32Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi
+----
+
+The component looks for keys matching the individual container names for the controller StatefulSet and CSI driver daemonset in the keys `controller` and `csi_driver` of this parameter respectively.
+
+The value of such a key -- if found -- is merged with the default resource requests and limits which are defined in the component.
+The value is expected to be a value which is valid as a container's `resources` field.
+
+[NOTE]
+====
+The component doesn't validate provided requests and limits.
+It's the user's responsibility to provide values which result in a valid container spec.
+====
+
+=== Example
+
+This example increases the memory limit for the `csi-cloudscale-plugin` container for both the controller and the csi_driver to `256Mi`.
+
+[source,yaml]
+----
+parameters:
+  csi_cloudscale:
+    resources:
+      controller:
+        csi-cloudscale-plugin:
+          limits:
+            memory: 256Mi
+      csi_driver:
+        csi-cloudscale-plugin:
+          limits:
+            memory: 256Mi
+----

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -12,4 +12,13 @@ parameters:
     classes: {}
     defaultClass: ''
 
-  csi_cloudscale: {}
+  csi_cloudscale:
+    resources:
+      controller:
+        csi-cloudscale-plugin:
+          limits:
+            memory: 1Gi
+      csi_driver:
+        csi-cloudscale-plugin:
+          limits:
+            cpu: 1000m

--- a/tests/golden/defaults/csi-cloudscale/csi-cloudscale/10_deployments.yaml
+++ b/tests/golden/defaults/csi-cloudscale/csi-cloudscale/10_deployments.yaml
@@ -26,6 +26,13 @@ spec:
           image: quay.io/k8scsi/csi-provisioner:v2.0.4
           imagePullPolicy: Always
           name: csi-provisioner
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 20m
+              memory: 32Mi
           volumeMounts:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
@@ -38,6 +45,13 @@ spec:
           image: quay.io/k8scsi/csi-attacher:v3.0.2
           imagePullPolicy: Always
           name: csi-attacher
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 20m
+              memory: 32Mi
           volumeMounts:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
@@ -52,6 +66,13 @@ spec:
           image: quay.io/k8scsi/csi-resizer:v1.0.1
           imagePullPolicy: IfNotPresent
           name: csi-resizer
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 20m
+              memory: 32Mi
           volumeMounts:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
@@ -71,6 +92,13 @@ spec:
           image: quay.io/cloudscalech/cloudscale-csi-plugin:v3.1.0
           imagePullPolicy: Always
           name: csi-cloudscale-plugin
+          resources:
+            limits:
+              cpu: 100m
+              memory: 1Gi
+            requests:
+              cpu: 20m
+              memory: 32Mi
           volumeMounts:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
@@ -125,6 +153,13 @@ spec:
                   - -c
                   - rm -rf /registration/csi.cloudscale.ch /registration/csi.cloudscale.ch-reg.sock
           name: csi-node-driver-registrar
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 20m
+              memory: 32Mi
           volumeMounts:
             - mountPath: /csi/
               name: plugin-dir
@@ -146,6 +181,13 @@ spec:
           image: quay.io/cloudscalech/cloudscale-csi-plugin:v3.1.0
           imagePullPolicy: Always
           name: csi-cloudscale-plugin
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 128Mi
+            requests:
+              cpu: 20m
+              memory: 32Mi
           securityContext:
             allowPrivilegeEscalation: true
             capabilities:


### PR DESCRIPTION
The component now sets the default resource requests and limits for all containers of the CSI driver and controller.
 
By default, the component sets requests of 20 milli-CPU and 32 MiB, and limits of 100 milli-CPU and 128 MiB for each container.

The PR also adds a parameter which allows users to adjust the requests and limits for individual containers. Note that the component oesn't validate the provided values, and it's the user's responsibility to provide values which result in valid container specs.

Fixes #24




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
