### PR TITLE
Remove default memory limits

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -77,7 +77,6 @@ local defaultResources = {
       },
       limits: {
         cpu: '100m',
-        memory: '128Mi',
       },
     },
     'csi-cloudscale-plugin': {
@@ -87,7 +86,6 @@ local defaultResources = {
       },
       limits: {
         cpu: '100m',
-        memory: '128Mi',
       },
     },
   },
@@ -99,7 +97,6 @@ local defaultResources = {
       },
       limits: {
         cpu: '100m',
-        memory: '128Mi',
       },
     },
     'csi-attacher': {
@@ -109,7 +106,6 @@ local defaultResources = {
       },
       limits: {
         cpu: '100m',
-        memory: '128Mi',
       },
     },
     'csi-resizer': {
@@ -119,7 +115,6 @@ local defaultResources = {
       },
       limits: {
         cpu: '100m',
-        memory: '128Mi',
       },
     },
     'csi-cloudscale-plugin': {
@@ -129,7 +124,6 @@ local defaultResources = {
       },
       limits: {
         cpu: '100m',
-        memory: '128Mi',
       },
     },
   },

--- a/tests/golden/defaults/csi-cloudscale/csi-cloudscale/10_deployments.yaml
+++ b/tests/golden/defaults/csi-cloudscale/csi-cloudscale/10_deployments.yaml
@@ -29,7 +29,6 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 128Mi
             requests:
               cpu: 20m
               memory: 32Mi
@@ -48,7 +47,6 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 128Mi
             requests:
               cpu: 20m
               memory: 32Mi
@@ -69,7 +67,6 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 128Mi
             requests:
               cpu: 20m
               memory: 32Mi
@@ -156,7 +153,6 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 128Mi
             requests:
               cpu: 20m
               memory: 32Mi
@@ -184,7 +180,6 @@ spec:
           resources:
             limits:
               cpu: 1000m
-              memory: 128Mi
             requests:
               cpu: 20m
               memory: 32Mi


### PR DESCRIPTION
We want to avoid a default configuration which can lead to pods crashlooping because they run into memory limits

Follow-up for #24 

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
