### PR TITLE
Allow resource requests and limits to be removed

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -160,7 +160,9 @@ local patch_manifest(object) =
           spec+: {
             containers: [
               c {
-                resources+: com.getValueOrDefault(resources, c.name, {}),
+                resources+: std.prune(
+                  com.getValueOrDefault(resources, c.name, {})
+                ),
               }
               for c in super.containers
             ],

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -121,6 +121,8 @@ The component looks for keys matching the individual container names for the con
 The value of such a key -- if found -- is merged with the default resource requests and limits which are defined in the component.
 The value is expected to be a value which is valid as a container's `resources` field.
 
+The component supports removing requests or limits by setting the corresponding fields to `null`.
+
 [NOTE]
 ====
 The component doesn't validate provided requests and limits.

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -19,6 +19,9 @@ parameters:
           limits:
             memory: 1Gi
       csi_driver:
+        csi-node-driver-registrar:
+          requests:
+            cpu: null
         csi-cloudscale-plugin:
           limits:
             cpu: 1000m

--- a/tests/golden/defaults/csi-cloudscale/csi-cloudscale/10_deployments.yaml
+++ b/tests/golden/defaults/csi-cloudscale/csi-cloudscale/10_deployments.yaml
@@ -154,7 +154,6 @@ spec:
             limits:
               cpu: 100m
             requests:
-              cpu: 20m
               memory: 32Mi
           volumeMounts:
             - mountPath: /csi/


### PR DESCRIPTION
Users can remove requests or limits configured higher up in the hierarchy by setting fields to `null`

Follow-up for #24 
## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.
- [x] Rebase after #27 is merged

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
