### PR TITLE
Remove default CPU limits for CSI driver containers

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -15,36 +15,24 @@ parameters:
           requests:
             cpu: 20m
             memory: 32Mi
-          limits:
-            cpu: 100m
         csi-attacher:
           requests:
             cpu: 20m
             memory: 32Mi
-          limits:
-            cpu: 100m
         csi-resizer:
           requests:
             cpu: 20m
             memory: 32Mi
-          limits:
-            cpu: 100m
         csi-cloudscale-plugin:
           requests:
             cpu: 20m
             memory: 32Mi
-          limits:
-            cpu: 100m
       csi_driver:
         csi-node-driver-registrar:
           requests:
             cpu: 20m
             memory: 32Mi
-          limits:
-            cpu: 100m
         csi-cloudscale-plugin:
           requests:
             cpu: 20m
             memory: 32Mi
-          limits:
-            cpu: 100m

--- a/tests/golden/defaults/csi-cloudscale/csi-cloudscale/10_deployments.yaml
+++ b/tests/golden/defaults/csi-cloudscale/csi-cloudscale/10_deployments.yaml
@@ -50,8 +50,6 @@ spec:
                   - rm -rf /registration/csi.cloudscale.ch /registration/csi.cloudscale.ch-reg.sock
           name: csi-node-driver-registrar
           resources:
-            limits:
-              cpu: 100m
             requests:
               memory: 32Mi
           volumeMounts:
@@ -152,8 +150,6 @@ spec:
           imagePullPolicy: IfNotPresent
           name: csi-provisioner
           resources:
-            limits:
-              cpu: 100m
             requests:
               cpu: 20m
               memory: 32Mi
@@ -170,8 +166,6 @@ spec:
           imagePullPolicy: IfNotPresent
           name: csi-attacher
           resources:
-            limits:
-              cpu: 100m
             requests:
               cpu: 20m
               memory: 32Mi
@@ -190,8 +184,6 @@ spec:
           imagePullPolicy: IfNotPresent
           name: csi-resizer
           resources:
-            limits:
-              cpu: 100m
             requests:
               cpu: 20m
               memory: 32Mi
@@ -216,7 +208,6 @@ spec:
           name: csi-cloudscale-plugin
           resources:
             limits:
-              cpu: 100m
               memory: 1Gi
             requests:
               cpu: 20m


### PR DESCRIPTION
Some of the work performed by the CSI drivers is very bursty (e.g. decrypting LUKS volumes), and took much longer than expected with the fairly aggressive CPU limits that were configured.

This commit completely removes the CPU limits, since they're not really necessary for a CSI driver.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
